### PR TITLE
Reinstate Python 3.7 test coverage

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 # Config file for automatic testing at travis-ci.org
 
-sudo: false
 language: python
 
 matrix:
@@ -13,8 +12,9 @@ matrix:
         env: TOX_ENV=py35
       - python: 3.6
         env: TOX_ENV=py36
-      # - python: 3.7
-      #   env: TOX_ENV=py37
+      - python: 3.7
+        dist: xenial
+        env: TOX_ENV=py37
       - python: pypy
         env: TOX_ENV=pypy
       - python: 3.6


### PR DESCRIPTION
This is essential to our development environment